### PR TITLE
Rename chunkedLayout parameter and add single chunk compression mode

### DIFF
--- a/IPNWB_Constants.ipf
+++ b/IPNWB_Constants.ipf
@@ -62,3 +62,28 @@ Constant NOISE_GEN_MERSENNE_TWISTER    = 2
 
 /// Maximum length of a valid name in bytes in Igor Pro.
 Constant MAX_OBJECT_NAME_LENGTH_IN_BYTES = 31
+
+/// @brief Convenience getters
+///
+/// Igor Pro does not allow cross IM access to constants
+/// @{
+Function GetNoCompression()
+	return NO_COMPRESSION
+End
+
+Function GetChunkedCompression()
+	return CHUNKED_COMPRESSION
+End
+
+Function GetSingleChunkCompression()
+	return SINGLE_CHUNK_COMPRESSION
+End
+/// @}
+
+/// @name Constants for the compression modes
+/// @anchor CompressionMode
+/// @{
+Constant NO_COMPRESSION           = 0x0
+Constant CHUNKED_COMPRESSION      = 0x1
+Constant SINGLE_CHUNK_COMPRESSION = 0x2
+/// @}

--- a/IPNWB_Utils.ipf
+++ b/IPNWB_Utils.ipf
@@ -166,22 +166,24 @@ End
 
 /// @brief Write a text dataset only if it is not equal to #PLACEHOLDER
 ///
-/// @param locationID                                  HDF5 identifier, can be a file or group
-/// @param name                                        Name of the HDF5 dataset
-/// @param str                                         Contents to write into the dataset
-/// @param chunkedLayout [optional, defaults to false] Use chunked layout with compression and shuffling. Will be ignored for small waves.
-Function WriteTextDatasetIfSet(locationID, name, str, [chunkedLayout])
+/// @param locationID                                               HDF5 identifier, can be a file or group
+/// @param name                                                     Name of the HDF5 dataset
+/// @param str                                                      Contents to write into the dataset
+/// @param compressionMode [optional, defaults to #NO_COMPRESSION]  Type of compression to use, one of @ref CompressionMode
+Function WriteTextDatasetIfSet(locationID, name, str, [compressionMode])
 	variable locationID
 	string name, str
-	variable chunkedLayout
+	variable compressionMode
 
-	chunkedLayout = ParamIsDefault(chunkedLayout) ? 0 : !!chunkedLayout
+	if(ParamIsDefault(compressionMode))
+		compressionMode = NO_COMPRESSION
+	endif
 
 	if(!cmpstr(str, PLACEHOLDER))
 		return NaN
 	endif
 
-	H5_WriteTextDataset(locationID, name, str=str, chunkedLayout=chunkedLayout)
+	H5_WriteTextDataset(locationID, name, str=str, compressionMode=compressionMode)
 End
 
 /// @brief Return 1 if the wave is a text wave, zero otherwise


### PR DESCRIPTION
Ever since the introduction of chunkedLayout setting this to 1 did two
things. It used chunking/shuffling *and* enabled GZIP compression.

As the size of the chunks is very fragile parameter to get right we
introduce a new mode, SINGLE_CHUNK_COMPRESSION, which just uses one
chunk for a dataset.

In order to properly test we need to convert all users of chunkedLayout
to the new compression mode flags.