### PR TITLE
H5_GroupExists: Speed it up

### DIFF
--- a/IPNWB_HDF5Helpers.ipf
+++ b/IPNWB_HDF5Helpers.ipf
@@ -594,8 +594,6 @@ threadsafe Function/S H5_ListGroupMembers(locationID, path)
 	variable locationID
 	string path
 
-	ASSERT_TS(H5_GroupExists(locationID, path), "H5_ListGroupMembers: " + path + " not in HDF5 file")
-
 	HDF5ListGroup/Z locationID, path
 	if(V_flag)
 		HDf5DumpErrors/CLR=1
@@ -613,8 +611,6 @@ End
 threadsafe Function/S H5_ListGroups(fileID, path)
 	variable fileID
 	string path
-
-	ASSERT_TS(H5_GroupExists(fileID, path), "H5_ListGroups: " + path + " not in HDF5 file")
 
 	HDF5ListGroup/TYPE=1/Z fileID, path
 	if(V_flag)

--- a/IPNWB_Reader.ipf
+++ b/IPNWB_Reader.ipf
@@ -518,8 +518,8 @@ Function [WAVE/Z sweep_number, WAVE/Z/T series] LoadSweepTable(variable location
 
 	groupID = H5_OpenGroup(locationID, path)
 	if(!IsNaN(groupID))
-		WAVE sweep_number = IPNWB#H5_LoadDataset(groupID, "sweep_number")
-		WAVE/T series = IPNWB#H5_LoadDataset(groupID, "series")
+		WAVE sweep_number = H5_LoadDataset(groupID, "sweep_number")
+		WAVE/T series = H5_LoadDataset(groupID, "series")
 		series[] = (series[p])[2,inf] // Remove leading group linker "G:"
 		HDF5CloseGroup/Z groupID
 		return [sweep_number, series]


### PR DESCRIPTION
Since the bugfix in be9fb354 (Change H5_OpenGroup and H5_GroupExists
Behaviour, 2020-01-22) H5_GroupExists is painfully slow. The reason for
that fix was that HDF5OpenGroup did not work with soft links in its
path.

This is fixed in the (unreleased) HDF5 XOP 2.0.3 and in the current IP9
beta version.

So let's use HDF5OpenGroup for IP9 and HDF5ListAttributes for IP8. The
latter is deemed less expensive compared to the existing HDF5ListGroup.

Close #25.