### PR TITLE
Changes for TTL channel epoch support in MIES

### DIFF
--- a/IPNWB_Reader.ipf
+++ b/IPNWB_Reader.ipf
@@ -687,7 +687,7 @@ static Function/WAVE GetEpochsWaveInternal(WAVE/T timeseries)
 		SetDimLabel ROWS, i, $uniqueTimeseries[i], epochsAll
 
 		Make/FREE/T/N=(MINIMUM_WAVE_SIZE, 4) epochs
-		SetEpochsDimensionLabels(epochs)
+		SetEpochsDimensionLabelsSingleChannel(epochs)
 		SetNumberInWaveNote(epochs, NOTE_INDEX, 0)
 
 		epochsAll[i] = epochs


### PR DESCRIPTION
related to https://github.com/AllenInstitute/MIES/pull/1791

- the dimension labels are actually only set for a single channel epoch wave