### PR TITLE
Increase precision of sampling rate attribute from %g to %.15g

### DIFF
--- a/IPNWB_Writer.ipf
+++ b/IPNWB_Writer.ipf
@@ -428,7 +428,7 @@ threadsafe Function WriteSingleChannel(locationID, path, version, p, tsp, [compr
 			sprintf channelTypeStr, "%s=%d", channelTypeStr, p.channelNumber
 		endif
 
-		sprintf source, "Device=%s;Sweep=%d;%s;ElectrodeNumber=%s;ElectrodeName=%s;SamplingRate=%s", p.device, p.sweep, channelTypeStr, num2str(p.electrodeNumber), p.electrodeName, num2str(p.samplingRate,"%g")
+		sprintf source, "Device=%s;Sweep=%d;%s;ElectrodeNumber=%s;ElectrodeName=%s;SamplingRate=%.15g", p.device, p.sweep, channelTypeStr, num2str(p.electrodeNumber), p.electrodeName, p.samplingRate
 
 		if(strlen(p.channelSuffixDesc) > 0 && strlen(p.channelSuffix) > 0)
 			ASSERT_TS(strsearch(p.channelSuffix, "=", 0) == -1, "WriteSingleChannel: channelSuffix must not contain an equals (=) symbol")


### PR DESCRIPTION
- %.15g represent the maximum precision with a FLOAT64 source