### PR TITLE
H5_WriteTextAttribute: Write attributes always as variable length UTF…

### DIFF
--- a/IPNWB_HDF5Helpers.ipf
+++ b/IPNWB_HDF5Helpers.ipf
@@ -235,9 +235,9 @@ threadsafe Function H5_WriteTextAttribute(locationID, attrName, path, [list, str
 	overwrite = ParamIsDefault(overwrite) ? 0 : !!overwrite
 
 	if(overwrite)
-		HDF5SaveData/A={attrName, forceSimpleDataSpace}/IGOR=0/REF=(refMode)/O/Z data, locationID, path
+		HDF5SaveData/A={attrName, forceSimpleDataSpace}/IGOR=0/REF=(refMode)/STRF={0, 0, 1}/O/Z data, locationID, path
 	else
-		HDF5SaveData/A={attrName, forceSimpleDataSpace}/IGOR=0/REF=(refMode)/Z data, locationID, path
+		HDF5SaveData/A={attrName, forceSimpleDataSpace}/IGOR=0/REF=(refMode)/STRF={0, 0, 1}/Z data, locationID, path
 	endif
 
 	if(V_flag)


### PR DESCRIPTION
…8 strings

This avoids a warning from dandi 0.63.0 like

[pywnb.GENERIC] /home/thomas/devel/mies/Packages/tests/Basic/input/AB_SweepsFromMultipleDevices-compressed-V2.nwb — error: nwb_version "b'2.2.4'" is not a proper semantic version. See http://semver.org

The Igor Pro help topic "HDF5 String Formats" explains the topic from Igor Pro's side.

The choice of writing in UTF8 (the 1 of the triplett) was motivated as NWB and HDMF always use UTF8 encoded strings, named "text" [1] in the schema language.

We also don't have any matches of "ascii" like in

$ git grep ascii core/ hdmf-common-schema/

so explicitly selecting UTF8 looks safe.

[1]: https://schema-language.readthedocs.io/en/latest/description.html#dtype